### PR TITLE
[Bugfix] Fix percent tax for payer

### DIFF
--- a/Core/src/net/tnemc/core/transaction/type/PayType.java
+++ b/Core/src/net/tnemc/core/transaction/type/PayType.java
@@ -77,7 +77,7 @@ public class PayType implements TransactionType {
     if(MainConfig.yaml().getBoolean("Core.Transactions.Pay.Tax.Enabled", false)) {
       final String tax = MainConfig.yaml().getString("Core.Transactions.Pay.Tax.Sender");
       TaxEntry entry;
-      if(tax.contains("\\%")) {
+      if(tax.contains("%")) {
         entry = new TaxEntry("percent", Double.parseDouble(tax.replace("%", "")));
       } else {
         entry = new TaxEntry("flat", Double.parseDouble(tax));


### PR DESCRIPTION
The `if` statement for the payer tax was expecting the pattern `9.9\\%` but only the `%` was removed before parsing.

Updated the `if` to match the pattern `9.9%`, same used for the receiver tax.