### PR TITLE
Fix Proxy Backlog Concurrency Issues

### DIFF
--- a/Bungee/src/net/tnemc/bungee/message/backlog/MessageData.java
+++ b/Bungee/src/net/tnemc/bungee/message/backlog/MessageData.java
@@ -18,8 +18,8 @@ package net.tnemc.bungee.message.backlog;
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * MessageData
@@ -28,8 +28,7 @@ import java.util.List;
  * @since 0.1.2.0
  */
 public class MessageData {
-
-  private final List<BacklogEntry> backlog = new LinkedList<>();
+  private final Queue<BacklogEntry> backlog = new ConcurrentLinkedQueue<>();
 
   private final String serverName;
 
@@ -43,7 +42,7 @@ public class MessageData {
     return serverName;
   }
 
-  public List<BacklogEntry> getBacklog() {
+  public Queue<BacklogEntry> getBacklog() {
 
     return backlog;
   }


### PR DESCRIPTION
This PR replaces the underlying data structure of backlog in MessageData.java from `LinkedList` to `ConcurrentLinkedQueue`.

#### 🔧 Why this change?

The backlog is accessed concurrently by multiple threads in proxy environments such as BungeeCord and Velocity:

- **Multiple servers may trigger backlog sends simultaneously**
- **New entries can be added while a backlog is being processed**
- **Netty’s event loop threads handle all communication asynchronously**

In such a multi-threaded environment, using a non-concurrent collection like `LinkedList` without explicit synchronization may leads to:

- Data inconsistency
- Unexpected behavior or missed messages

You can see an example of this issue in the following log: https://mclo.gs/pqkPSqa
#### ✅ What was changed?

Replaced:

```java
private final Queue<BacklogEntry> backlog = new LinkedList<>();
```


With:

```java
private final Queue<BacklogEntry> backlog = new ConcurrentLinkedQueue<>();
```